### PR TITLE
Tournament logistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ game-log.txt
 test-log.txt
 sdks/clojure/target
 .vscode
+.players_env

--- a/server/.players_env
+++ b/server/.players_env
@@ -1,9 +1,0 @@
-# Copy this file to .players_env
-# Add players IPs and designated ports to that file
-# Example for teams "RED" and "BLUE" below
-# Be sure to include the "_IP" and "_PORT" suffix
-# Then start a match with `rake "head_to_head[RED,BLUE]"`
-RED_IP="127.0.0.1"
-RED_PORT="9090"
-BLUE_IP="127.0.0.1"
-BLUE_PORT="9091"

--- a/server/.players_env
+++ b/server/.players_env
@@ -1,0 +1,7 @@
+# Add players IPs and designated ports here
+# Then start a match with `rake "head_to_head[RED,BLUE]"`
+# Example for teams "RED" and "BLUE"
+RED_IP="127.0.0.1"
+RED_PORT="9090"
+BLUE_IP="127.0.0.1"
+BLUE_PORT="9091"

--- a/server/.players_env
+++ b/server/.players_env
@@ -1,6 +1,8 @@
-# Add players IPs and designated ports here
+# Copy this file to .players_env
+# Add players IPs and designated ports to that file
+# Example for teams "RED" and "BLUE" below
+# Be sure to include the "_IP" and "_PORT" suffix
 # Then start a match with `rake "head_to_head[RED,BLUE]"`
-# Example for teams "RED" and "BLUE"
 RED_IP="127.0.0.1"
 RED_PORT="9090"
 BLUE_IP="127.0.0.1"

--- a/server/.players_env.example
+++ b/server/.players_env.example
@@ -1,0 +1,7 @@
+# Add players IPs and designated ports here
+# Then start a match with `rake "head_to_head[RED,BLUE]"`
+# Example for teams "RED" and "BLUE"
+RED_IP="127.0.0.1"
+RED_PORT="9090"
+BLUE_IP="127.0.0.1"
+BLUE_PORT="9091"

--- a/server/.players_env.example
+++ b/server/.players_env.example
@@ -1,6 +1,9 @@
-# Add players IPs and designated ports here
+# Copy this file to .players_env
+# Add players IPs and designated ports to that file
+# Example for teams "RED" and "BLUE" below
+# Be sure to include the "_IP" and "_PORT" suffix
 # Then start a match with `rake "head_to_head[RED,BLUE]"`
-# Example for teams "RED" and "BLUE"
+
 RED_IP="127.0.0.1"
 RED_PORT="9090"
 BLUE_IP="127.0.0.1"

--- a/server/Rakefile
+++ b/server/Rakefile
@@ -106,6 +106,20 @@ class CodeStatistics #:nodoc:
 	end
 end
 
+def load_env_file(file = '.env')
+	return unless File.exist?(file)
+	
+	File.readlines(file).each do |line|
+		# Remove comments and empty lines
+		line.strip!
+		next if line.empty? || line.start_with?('#')
+		
+		# Split by the first "=" and add to ENV
+		key, value = line.split('=', 2)
+		ENV[key] = value
+	end
+end
+
 
 STATS_DIRECTORIES = [
 	# %w(Components          components/),
@@ -125,14 +139,28 @@ task :installer, [:ip] do |t, args|
 	sh "ocra --icon AtomicRTS.ico --output game.exe --innosetup inno.iss --chdir-first --no-lzma src/app.rb assets/**/* maps/* -- -p1 #{args[:ip]} "
 end
 
-
 task :stats do
   CodeStatistics.new(*STATS_DIRECTORIES).to_s
+end
+
+task :players_env do
+	load_env_file('.players_env')
 end
 
 desc 'run single player game with p1 on 9090'
 task :run do
   ruby 'src/app.rb -f'
+end
+
+task :head_to_head, [:first, :second] => :players_env do |t, args|
+	puts "Head to Head: #{args[:first]} vs #{args[:second]}"
+	p1_ip = "#{args[:first]}_IP"
+	p1_port = "#{args[:first]}_PORT"
+	p2_ip = "#{args[:second]}_IP"
+	p2_port = "#{args[:second]}_PORT"
+	puts "#{args[:first]}: #{ENV[p1_ip]}:#{ENV[p1_port]}"
+	puts "#{args[:second]}: #{ENV[p2_ip]}:#{ENV[p2_port]}"
+	ruby "src/app.rb -f -p1 #{ENV[p1_ip]} -p1p #{ENV[p1_port]} -p2 #{ENV[p2_ip]} -p2p #{ENV[p2_port]}"
 end
 
 task default: :run

--- a/server/Rakefile
+++ b/server/Rakefile
@@ -108,12 +108,12 @@ end
 
 def load_env_file(file = '.env')
 	return unless File.exist?(file)
-	
+
 	File.readlines(file).each do |line|
 		# Remove comments and empty lines
 		line.strip!
 		next if line.empty? || line.start_with?('#')
-		
+
 		# Split by the first "=" and add to ENV
 		key, value = line.split('=', 2)
 		ENV[key] = value

--- a/server/Rakefile
+++ b/server/Rakefile
@@ -152,7 +152,7 @@ task :run do
   ruby 'src/app.rb -f'
 end
 
-task :head_to_head, [:first, :second] => :players_env do |t, args|
+task :head_to_head, [:first, :second, :other_args] => :players_env do |t, args|
 	puts "Head to Head: #{args[:first]} vs #{args[:second]}"
 	p1_ip = "#{args[:first]}_IP"
 	p1_port = "#{args[:first]}_PORT"
@@ -160,7 +160,7 @@ task :head_to_head, [:first, :second] => :players_env do |t, args|
 	p2_port = "#{args[:second]}_PORT"
 	puts "#{args[:first]}: #{ENV[p1_ip]}:#{ENV[p1_port]}"
 	puts "#{args[:second]}: #{ENV[p2_ip]}:#{ENV[p2_port]}"
-	ruby "src/app.rb -f -p1 #{ENV[p1_ip]} -p1p #{ENV[p1_port]} -p2 #{ENV[p2_ip]} -p2p #{ENV[p2_port]}"
+	ruby "src/app.rb -f -p1 #{ENV[p1_ip]} -p1p #{ENV[p1_port]} -p2 #{ENV[p2_ip]} -p2p #{ENV[p2_port]} #{args[:other_args]}"
 end
 
 task default: :run


### PR DESCRIPTION
Trying to find a better way to manage matchups when running the tournament.
In the past it has been challenging to manage the right IP and Port for each team when queueing up the matches.
The intention of this PR is to allow us to start matches based on team name rather than IP and Port.

Proposed use:
1. Assign a unique port number to each team, the team will consistently use that port for every match
2. Ask each team to provide a team name and the IP of the laptop that will be used during competition.
3. `cp server/.players_env.example server/.players_env`
4. Add an IP and Port entry for each team (you will need to replace spaces and special characters)
    ```
    LIONS_IP="10.0.1.101"
    LIONS_PORT="5000"
    JETS_IP="10.0.1.100"
    JETS_PORT="5001"
    ```
5. Start matches using the head_to_head rake task and the two team names: `rake "head_to_head[LIONS,JETS]"`